### PR TITLE
CF-22225 Exclude org.apache.phoenix.shaded.javax.servlet.ServletContainerInitializer SPI from uber-jar

### DIFF
--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -101,6 +101,7 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/license/*</exclude>
+                    <exclude>META-INF/services/javax.servlet.ServletContainerInitializer</exclude>
                     <exclude>LICENSE.*</exclude>
                     <exclude>NOTICE.*</exclude>
                   </excludes>


### PR DESCRIPTION
Since phoenix-queryserver-thin-client was introduced into spark's dp-hbase module it's included transitively into Reporting SOA. Reporting war cannot startup on server because of org.apache.phoenix.shaded.javax.servlet.ServletContainerInitializer SPI  is not in the classpath. Shadowing of this SPI was done a long time ago by this line `<pattern>javax.servlet</pattern>`, probably accidentally.